### PR TITLE
Add the controller deployment name to the configuration

### DIFF
--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -134,7 +134,7 @@ type Cluster struct {
 // Controller contains additional controller configuration when working with Red Sky on a specific cluster
 type Controller struct {
 	// DeploymentName is the name of the controller deployment object
-	DeploymentName string `json:"deploymentName,omitempty"` // TODO Use as an instance label?
+	DeploymentName string `json:"deploymentName,omitempty"`
 	// Namespace overrides the default namespace to use during configuration
 	Namespace string `json:"namespace,omitempty"`
 	// RegistrationClientURI is the fully qualified URL of the client configuration endpoint for the controller's client

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -133,6 +133,8 @@ type Cluster struct {
 
 // Controller contains additional controller configuration when working with Red Sky on a specific cluster
 type Controller struct {
+	// DeploymentName is the name of the controller deployment object
+	DeploymentName string `json:"deploymentName,omitempty"` // TODO Use as an instance label?
 	// Namespace overrides the default namespace to use during configuration
 	Namespace string `json:"namespace,omitempty"`
 	// RegistrationClientURI is the fully qualified URL of the client configuration endpoint for the controller's client

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -173,6 +173,7 @@ func (d *defaults) applyControllerDefaults() error {
 	for i := range d.cfg.Controllers {
 		ctrl := &d.cfg.Controllers[i].Controller
 
+		defaultString(&ctrl.DeploymentName, "redsky-controller-manager")
 		defaultString(&ctrl.Namespace, "redsky-system")
 	}
 	return nil


### PR DESCRIPTION
There are a few places in the init process where it would be good have the name of the deployment configurable to avoid hard coding it. I'd like to get it into the configuration even if we don't start using right away.